### PR TITLE
feat: Configurable compendiums for character creation wizard

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1079,5 +1079,26 @@
   "TB2E.Wizard.Nature.Changeling.Q2.No": "I remain secretive about my true nature — Gain a second wise",
   "TB2E.Wizard.Nature.Changeling.Q3.Flavor": "Do you use your troll strength to break and rend?",
   "TB2E.Wizard.Nature.Changeling.Q3.Yes": "I use my troll strength — Nature +1",
-  "TB2E.Wizard.Nature.Changeling.Q3.No": "I hide my strength and origins — Huldrekall to level 2"
+  "TB2E.Wizard.Nature.Changeling.Q3.No": "I hide my strength and origins — Huldrekall to level 2",
+
+  "TB2E.Settings.WizardCompendiums.Name": "Wizard Compendiums",
+  "TB2E.Settings.WizardCompendiums.Label": "Configure",
+  "TB2E.Settings.WizardCompendiums.Hint": "Choose which compendium packs the character creation wizard uses for each item category.",
+  "TB2E.Settings.WizardCompendiums.GroupWeaponsArmor": "Weapons & Armor",
+  "TB2E.Settings.WizardCompendiums.GroupMagic": "Magic",
+  "TB2E.Settings.WizardCompendiums.GroupEquipment": "Equipment",
+  "TB2E.Settings.WizardCompendiums.ResetDefaults": "Reset to Defaults",
+  "TB2E.Settings.WizardCompendiums.Pack.Weapons": "Weapons",
+  "TB2E.Settings.WizardCompendiums.Pack.Armor": "Armor",
+  "TB2E.Settings.WizardCompendiums.Pack.Spells": "Spells",
+  "TB2E.Settings.WizardCompendiums.Pack.TheurgeRelics": "Theurge Relics",
+  "TB2E.Settings.WizardCompendiums.Pack.TheurgeInvocations": "Theurge Invocations",
+  "TB2E.Settings.WizardCompendiums.Pack.ShamanicRelics": "Shamanic Relics",
+  "TB2E.Settings.WizardCompendiums.Pack.ShamanicInvocations": "Shamanic Invocations",
+  "TB2E.Settings.WizardCompendiums.Pack.Containers": "Containers",
+  "TB2E.Settings.WizardCompendiums.Pack.Equipment": "Equipment",
+  "TB2E.Settings.WizardCompendiums.Pack.LightSources": "Light Sources",
+  "TB2E.Settings.WizardCompendiums.Pack.FoodAndDrink": "Food & Drink",
+  "TB2E.Settings.WizardCompendiums.Pack.Clothing": "Clothing",
+  "TB2E.Settings.WizardCompendiums.Pack.MagicalReligious": "Magical & Religious"
 }

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -2,3 +2,4 @@ export * as actor from "./actor/_module.mjs";
 export * as conflict from "./conflict/_module.mjs";
 export * as item from "./item/_module.mjs";
 export { default as GrindTracker } from "./grind-tracker.mjs";
+export { default as WizardCompendiumsConfig } from "./settings/wizard-compendiums-config.mjs";

--- a/module/applications/actor/character-wizard.mjs
+++ b/module/applications/actor/character-wizard.mjs
@@ -2,7 +2,7 @@ import {
   CLASS_DEFS, HOMETOWNS, NATURE_QUESTIONS, UPBRINGING_SKILLS, SOCIAL_SKILLS,
   SPECIALTY_SKILLS, REQUIRED_WISES, AGE_RANGES, SPELL_SCHOOL_TABLE,
   THEURGE_RELIC_TABLE, SHAMAN_RELIC_TABLE, WEAPON_RESTRICTIONS, ARMOR_RESTRICTIONS,
-  SHIELD_ELIGIBLE_CLASSES, STARTING_EQUIPMENT, PACKS, STEPS, applySkill,
+  SHIELD_ELIGIBLE_CLASSES, STARTING_EQUIPMENT, getWizardPacks, STEPS, applySkill,
   shouldSkipUpbringing, getAvailableHometowns, buildSkillsMap
 } from "../../data/actor/chargen.mjs";
 
@@ -828,7 +828,8 @@ export default class CharacterWizard extends HandlebarsApplicationMixin(Applicat
 
   /** Load weapon names from compendium for unrestricted classes. */
   async #loadWeaponsFromCompendium() {
-    const pack = game.packs.get(PACKS.weapons);
+    const packs = getWizardPacks();
+    const pack = game.packs.get(packs.weapons);
     if ( !pack ) return;
     const index = await pack.getIndex();
     const container = this.element.querySelector(".weapon-list");
@@ -849,11 +850,12 @@ export default class CharacterWizard extends HandlebarsApplicationMixin(Applicat
     const container = this.element.querySelector(".equipment-list");
     if ( !container ) return;
 
+    const packs = getWizardPacks();
     const allowedNames = new Set(STARTING_EQUIPMENT);
     const selectedNames = new Set(this.#state.selectedEquipment.map(e => e.name));
     const packIds = [
-      PACKS.equipment, PACKS.lightSources, PACKS.foodAndDrink,
-      PACKS.containers, PACKS.clothing, PACKS.magicalReligious
+      packs.equipment, packs.lightSources, packs.foodAndDrink,
+      packs.containers, packs.clothing, packs.magicalReligious
     ];
 
     for ( const packId of packIds ) {
@@ -1367,31 +1369,32 @@ export default class CharacterWizard extends HandlebarsApplicationMixin(Applicat
     }
 
     // Import compendium items (weapons, armor, spells, relics, invocations, equipment).
+    const packs = getWizardPacks();
     const itemsToCreate = [];
 
     // Weapon (single selection, or auto-dagger for thief).
     const weaponName = s.selectedWeapon || (s.class === "thief" ? "Dagger" : null);
     if ( weaponName ) {
-      const item = await this.#findCompendiumItem(PACKS.weapons, weaponName);
+      const item = await this.#findCompendiumItem(packs.weapons, weaponName);
       if ( item ) itemsToCreate.push(item.toObject());
     }
 
     // Shield (if chosen as additional weapon).
     if ( s.hasShield ) {
-      const item = await this.#findCompendiumItem(PACKS.weapons, "Shield");
+      const item = await this.#findCompendiumItem(packs.weapons, "Shield");
       if ( item ) itemsToCreate.push(item.toObject());
     }
 
     // Armor.
     for ( const armorName of s.selectedArmor ) {
-      const item = await this.#findCompendiumItem(PACKS.armor, armorName);
+      const item = await this.#findCompendiumItem(packs.armor, armorName);
       if ( item ) itemsToCreate.push(item.toObject());
     }
 
     // Spells (magician).
     if ( s.class === "magician" && s.spells.length ) {
       for ( const spellName of s.spells ) {
-        const item = await this.#findCompendiumItem(PACKS.spells, spellName);
+        const item = await this.#findCompendiumItem(packs.spells, spellName);
         if ( item ) itemsToCreate.push(item.toObject());
       }
     }
@@ -1399,12 +1402,12 @@ export default class CharacterWizard extends HandlebarsApplicationMixin(Applicat
     // Relics and invocations (theurge).
     if ( s.class === "theurge" ) {
       for ( const relicName of s.relics ) {
-        const item = await this.#findCompendiumItem(PACKS.theurgeRelics, relicName);
+        const item = await this.#findCompendiumItem(packs.theurgeRelics, relicName);
         if ( item ) itemsToCreate.push(item.toObject());
         else itemsToCreate.push({ name: relicName, type: "relic", system: { tier: "minor" } });
       }
       for ( const invName of s.invocations ) {
-        const item = await this.#findCompendiumItem(PACKS.theurgeInvocations, invName);
+        const item = await this.#findCompendiumItem(packs.theurgeInvocations, invName);
         if ( item ) itemsToCreate.push(item.toObject());
         else itemsToCreate.push({ name: invName, type: "invocation", system: {} });
       }
@@ -1413,12 +1416,12 @@ export default class CharacterWizard extends HandlebarsApplicationMixin(Applicat
     // Relics and invocations (shaman).
     if ( s.class === "shaman" ) {
       for ( const relicName of s.relics ) {
-        const item = await this.#findCompendiumItem(PACKS.shamanicRelics, relicName);
+        const item = await this.#findCompendiumItem(packs.shamanicRelics, relicName);
         if ( item ) itemsToCreate.push(item.toObject());
         else itemsToCreate.push({ name: relicName, type: "relic", system: { tier: "minor" } });
       }
       for ( const invName of s.invocations ) {
-        const item = await this.#findCompendiumItem(PACKS.shamanicInvocations, invName);
+        const item = await this.#findCompendiumItem(packs.shamanicInvocations, invName);
         if ( item ) itemsToCreate.push(item.toObject());
         else itemsToCreate.push({ name: invName, type: "invocation", system: {} });
       }
@@ -1427,7 +1430,7 @@ export default class CharacterWizard extends HandlebarsApplicationMixin(Applicat
     // Pack (satchel or backpack).
     if ( s.packType ) {
       const packName = s.packType === "backpack" ? "Backpack" : "Satchel";
-      const item = await this.#findCompendiumItem(PACKS.containers, packName);
+      const item = await this.#findCompendiumItem(packs.containers, packName);
       if ( item ) itemsToCreate.push(item.toObject());
     }
 

--- a/module/applications/settings/wizard-compendiums-config.mjs
+++ b/module/applications/settings/wizard-compendiums-config.mjs
@@ -1,0 +1,100 @@
+import { DEFAULT_PACKS, PACK_GROUPS, PACK_LABELS } from "../../data/actor/chargen.mjs";
+
+const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
+
+/**
+ * Settings form that lets the GM choose which compendium packs the character creation wizard uses.
+ */
+export default class WizardCompendiumsConfig extends HandlebarsApplicationMixin(ApplicationV2) {
+
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    id: "wizard-compendiums-config",
+    tag: "form",
+    window: {
+      title: "TB2E.Settings.WizardCompendiums.Name",
+      contentClasses: ["standard-form"]
+    },
+    form: {
+      closeOnSubmit: true,
+      handler: WizardCompendiumsConfig.#onSubmit
+    },
+    position: { width: 480 },
+    actions: {
+      reset: WizardCompendiumsConfig.#onReset
+    }
+  };
+
+  /** @override */
+  static PARTS = {
+    form: {
+      template: "systems/tb2e/templates/settings/wizard-compendiums.hbs",
+      scrollable: [""]
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext(options) {
+    const overrides = game.settings.get("tb2e", "wizardCompendiums");
+    const current = { ...DEFAULT_PACKS, ...overrides };
+
+    // Build the list of all available Item-type packs.
+    const availablePacks = [];
+    for ( const pack of game.packs ) {
+      if ( pack.metadata.type !== "Item" ) continue;
+      availablePacks.push({ collection: pack.collection, label: pack.metadata.label });
+    }
+    availablePacks.sort((a, b) => a.label.localeCompare(b.label));
+
+    // Build grouped fields for the template.
+    const groups = PACK_GROUPS.map(group => ({
+      label: group.label,
+      fields: group.keys.map(key => ({
+        key,
+        label: PACK_LABELS[key],
+        value: current[key],
+        default: DEFAULT_PACKS[key],
+        choices: availablePacks
+      }))
+    }));
+
+    return {
+      groups,
+      buttons: [
+        { type: "reset", label: "TB2E.Settings.WizardCompendiums.ResetDefaults", icon: "fa-solid fa-arrow-rotate-left", action: "reset" },
+        { type: "submit", label: "SETTINGS.Save", icon: "fa-solid fa-floppy-disk" }
+      ]
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle form submission — save only the overridden (non-default) values.
+   * @param {SubmitEvent} event
+   * @param {HTMLFormElement} form
+   * @param {FormDataExtended} formData
+   */
+  static async #onSubmit(event, form, formData) {
+    const data = formData.object;
+    const overrides = {};
+    for ( const [key, defaultPack] of Object.entries(DEFAULT_PACKS) ) {
+      const value = data[key];
+      if ( value && value !== defaultPack ) overrides[key] = value;
+    }
+    await game.settings.set("tb2e", "wizardCompendiums", overrides);
+  }
+
+  /* -------------------------------------------- */
+
+  /** Reset all packs to defaults. */
+  static async #onReset() {
+    await game.settings.set("tb2e", "wizardCompendiums", {});
+    this.render();
+  }
+}

--- a/module/data/actor/chargen.mjs
+++ b/module/data/actor/chargen.mjs
@@ -530,8 +530,8 @@ export const SHIELD_ELIGIBLE_CLASSES = ["outcast", "theurge", "warrior", "shaman
 /*  Compendium Pack Names                       */
 /* -------------------------------------------- */
 
-/** Pack slugs for compendium lookups. */
-export const PACKS = {
+/** Default pack slugs for compendium lookups. */
+export const DEFAULT_PACKS = {
   weapons: "tb2e.weapons",
   armor: "tb2e.armor",
   spells: "tb2e.spells",
@@ -545,6 +545,45 @@ export const PACKS = {
   foodAndDrink: "tb2e.food-and-drink",
   clothing: "tb2e.clothing",
   magicalReligious: "tb2e.magical-religious"
+};
+
+/**
+ * Resolve wizard compendium packs, merging any GM overrides from the wizardCompendiums setting.
+ * @returns {Record<string, string>}
+ */
+export function getWizardPacks() {
+  const overrides = game.settings.get("tb2e", "wizardCompendiums");
+  return { ...DEFAULT_PACKS, ...overrides };
+}
+
+/**
+ * Pack groups for the settings UI.
+ * @type {Array<{label: string, keys: string[]}>}
+ */
+export const PACK_GROUPS = [
+  { label: "TB2E.Settings.WizardCompendiums.GroupWeaponsArmor", keys: ["weapons", "armor"] },
+  { label: "TB2E.Settings.WizardCompendiums.GroupMagic", keys: ["spells", "theurgeRelics", "theurgeInvocations", "shamanicRelics", "shamanicInvocations"] },
+  { label: "TB2E.Settings.WizardCompendiums.GroupEquipment", keys: ["containers", "equipment", "lightSources", "foodAndDrink", "clothing", "magicalReligious"] }
+];
+
+/**
+ * Human-readable labels for each pack key.
+ * @type {Record<string, string>}
+ */
+export const PACK_LABELS = {
+  weapons: "TB2E.Settings.WizardCompendiums.Pack.Weapons",
+  armor: "TB2E.Settings.WizardCompendiums.Pack.Armor",
+  spells: "TB2E.Settings.WizardCompendiums.Pack.Spells",
+  theurgeRelics: "TB2E.Settings.WizardCompendiums.Pack.TheurgeRelics",
+  theurgeInvocations: "TB2E.Settings.WizardCompendiums.Pack.TheurgeInvocations",
+  shamanicRelics: "TB2E.Settings.WizardCompendiums.Pack.ShamanicRelics",
+  shamanicInvocations: "TB2E.Settings.WizardCompendiums.Pack.ShamanicInvocations",
+  containers: "TB2E.Settings.WizardCompendiums.Pack.Containers",
+  equipment: "TB2E.Settings.WizardCompendiums.Pack.Equipment",
+  lightSources: "TB2E.Settings.WizardCompendiums.Pack.LightSources",
+  foodAndDrink: "TB2E.Settings.WizardCompendiums.Pack.FoodAndDrink",
+  clothing: "TB2E.Settings.WizardCompendiums.Pack.Clothing",
+  magicalReligious: "TB2E.Settings.WizardCompendiums.Pack.MagicalReligious"
 };
 
 /**

--- a/system.json
+++ b/system.json
@@ -1,10 +1,10 @@
 {
   "id": "tb2e",
   "title": "Torchbearer 2nd Edition",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "url": "https://github.com/adamhjk/tb2e-foundry-vtt",
   "manifest": "https://github.com/adamhjk/tb2e-foundry-vtt/releases/latest/download/system.json",
-  "download": "https://github.com/adamhjk/tb2e-foundry-vtt/releases/download/release-0.2.4/tb2e-release-0.2.4.zip",
+  "download": "https://github.com/adamhjk/tb2e-foundry-vtt/releases/download/release-0.2.5/tb2e-release-0.2.5.zip",
   "compatibility": {
     "minimum": "13",
     "verified": "13"

--- a/tb2e.mjs
+++ b/tb2e.mjs
@@ -8,6 +8,7 @@ import { activatePostRollListeners, activateNatureCrisisListeners, activateWiseA
 import { activateSpellSourceListeners } from "./module/dice/spell-casting.mjs";
 import { activateBurdenListeners } from "./module/dice/invocation-casting.mjs";
 import { activateGrindConditionListeners } from "./module/applications/grind-tracker.mjs";
+import WizardCompendiumsConfig from "./module/applications/settings/wizard-compendiums-config.mjs";
 
 Hooks.once("init", function() {
   globalThis.tb2e = game.tb2e = { dice, conflictPanel: null, grindTracker: null };
@@ -16,6 +17,22 @@ Hooks.once("init", function() {
   game.settings.register("tb2e", "grindPhase", { scope: "world", config: false, type: String, default: "adventure" });
   game.settings.register("tb2e", "grindTurn", { scope: "world", config: false, type: Number, default: 1 });
   game.settings.register("tb2e", "grindExtreme", { scope: "world", config: false, type: Boolean, default: false });
+
+  // Register wizard compendium pack overrides.
+  game.settings.register("tb2e", "wizardCompendiums", {
+    scope: "world",
+    config: false,
+    type: Object,
+    default: {}
+  });
+  game.settings.registerMenu("tb2e", "wizardCompendiums", {
+    name: "TB2E.Settings.WizardCompendiums.Name",
+    label: "TB2E.Settings.WizardCompendiums.Label",
+    hint: "TB2E.Settings.WizardCompendiums.Hint",
+    icon: "fa-solid fa-book",
+    type: WizardCompendiumsConfig,
+    restricted: true
+  });
 
   CONFIG.TB2E = TB2E;
 

--- a/templates/settings/wizard-compendiums.hbs
+++ b/templates/settings/wizard-compendiums.hbs
@@ -1,0 +1,17 @@
+<div class="wizard-compendiums-config">
+  {{#each groups}}
+  <fieldset>
+    <legend>{{localize label}}</legend>
+    {{#each fields}}
+    <div class="form-group">
+      <label for="{{key}}">{{localize label}}</label>
+      <select name="{{key}}" id="{{key}}">
+        {{#each choices}}
+        <option value="{{collection}}" {{#if (eq collection ../value)}}selected{{/if}}>{{label}}</option>
+        {{/each}}
+      </select>
+    </div>
+    {{/each}}
+  </fieldset>
+  {{/each}}
+</div>


### PR DESCRIPTION
## Summary

- Add a GM-only **Wizard Compendiums** world setting that lets each of the 13 pack slots used by the character creation wizard be pointed at any Item-type compendium (world, module, or system)
- Built-in tb2e packs remain the defaults; only overrides are stored
- Settings form groups packs by category (Weapons & Armor, Magic, Equipment) with a Reset to Defaults button

Closes #2

## Changes

- `chargen.mjs`: Rename `PACKS` to `DEFAULT_PACKS`, add `getWizardPacks()` resolver + pack metadata constants
- `character-wizard.mjs`: Replace all hardcoded `PACKS.x` with dynamic `getWizardPacks()` calls
- `wizard-compendiums-config.mjs` (new): `ApplicationV2` settings form with grouped dropdowns
- `wizard-compendiums.hbs` (new): Handlebars template for the settings form
- `tb2e.mjs`: Register `wizardCompendiums` Object setting + GM-only settings menu
- `system.json`: Bump version to 0.2.5
- `lang/en.json`: Add 21 localization keys

## Test plan

- [ ] Open Game Settings > Configure Settings — "Wizard Compendiums" menu appears for GM only
- [ ] Click Configure — form shows all 13 pack slots with correct tb2e defaults
- [ ] Create a world compendium (Item type), override a pack slot, run the wizard — items load from the custom pack
- [ ] Reset to Defaults — wizard reverts to built-in packs
- [ ] Verify equipment, spell, and relic/invocation steps all respect overrides
- [ ] Verify non-GM players cannot see the settings menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)