### PR TITLE
feat: Consolidate grind condition chat messages into a single card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ Foundry VTT restricts document updates to owners. The mailbox pattern works as f
 | Versus finalize | `flags.tb2e.pendingVersusFinalize` | Actor | `updateActor` (in `tb2e.mjs`) |
 | Conflict HP | `flags.tb2e.pendingConflictHP` | Actor | `updateActor` (in `tb2e.mjs`) |
 | Light extinguish | `flags.tb2e.pendingLightExtinguish` | Actor | `updateActor` (in `tb2e.mjs`) |
+| Grind condition apply | `flags.tb2e.pendingGrindApply` | Actor | `updateActor` (in `tb2e.mjs`) |
 
 ## Unlinked Actors (Synthetic Tokens)
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -910,6 +910,7 @@
   "TB2E.GrindTracker.ConditionLabel": "The Grind",
   "TB2E.GrindTracker.ConditionBody": "The grind ticks — {name} suffers the next condition.",
   "TB2E.GrindTracker.ApplyCondition": "Apply {condition}",
+  "TB2E.GrindTracker.ApplyAll": "Apply All Conditions",
   "TB2E.GrindTracker.ConditionApplied": "Applied",
 
   "TB2E.Light.Full": "Full Light",

--- a/less/chat/grind-cards.less
+++ b/less/chat/grind-cards.less
@@ -62,3 +62,53 @@
   letter-spacing: 0.06em;
   color: var(--tb-amber-bright);
 }
+
+/* -------------------------------------------- */
+/*  Consolidated Grind Card                     */
+/* -------------------------------------------- */
+
+.grind-consolidated-card .grind-entries {
+  display: flex;
+  flex-direction: column;
+}
+
+.grind-consolidated-card .grind-entry {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--tb-border);
+}
+
+.grind-consolidated-card .grind-entry .card-portrait {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  object-fit: cover;
+  border: 1px solid var(--tb-red);
+  flex-shrink: 0;
+}
+
+.grind-consolidated-card .grind-entry .card-name {
+  flex: 1;
+  min-width: 0;
+  font-weight: bold;
+  font-size: 0.85rem;
+}
+
+.grind-consolidated-card .grind-apply-btn {
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.grind-consolidated-card .grind-entry--applied {
+  opacity: 0.7;
+}
+
+.grind-consolidated-card .grind-applied-label {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: var(--tb-green);
+}

--- a/module/applications/grind-tracker.mjs
+++ b/module/applications/grind-tracker.mjs
@@ -340,16 +340,18 @@ export default class GrindTracker extends HandlebarsApplicationMixin(Application
       }
     }
 
-    // On grind turns: announce + post per-character condition cards
+    // On grind turns: post a single consolidated condition card
     if ( cyclePos === maxTurns ) {
-      await GrindTracker.#postGrindTickCard(next);
-      const condOrder = ["hungry", "exhausted", "angry", "sick", "injured", "afraid", "dead"];
+      const entries = [];
       for ( const actor of game.actors ) {
         if ( actor.type !== "character" || !grindSceneActorIds.has(actor.id) ) continue;
         const conds = actor.system.conditions;
-        const nextCondKey = condOrder.find(k => !conds[k]) ?? null;
+        const nextCondKey = GRIND_ORDER.find(k => !conds[k]) ?? null;
         if ( !nextCondKey ) continue;
-        await GrindTracker.#postGrindConditionCard(actor, nextCondKey);
+        entries.push({ actorId: actor.id, actorImg: actor.img, actorName: actor.name, condKey: nextCondKey });
+      }
+      if ( entries.length ) {
+        await GrindTracker.#postConsolidatedGrindCard(next, entries);
       }
     }
 
@@ -381,48 +383,19 @@ export default class GrindTracker extends HandlebarsApplicationMixin(Application
   }
 
   /**
-   * Post a single game-level card announcing the Grind has ticked.
+   * Post a single consolidated card listing all grind conditions with per-character Apply buttons.
    * @param {number} turn  The new (post-advance) turn number.
+   * @param {Array<{actorId: string, actorImg: string, actorName: string, condKey: string}>} entries
    */
-  static async #postGrindTickCard(turn) {
-    const content = await foundry.applications.handlebars.renderTemplate(
-      "systems/tb2e/templates/chat/grind-tick.hbs",
-      {
-        body: game.i18n.format("TB2E.GrindTracker.GrindTicksBody", { turn })
-      }
-    );
+  static async #postConsolidatedGrindCard(turn, entries) {
+    const flagEntries = entries.map(e => ({ actorId: e.actorId, condKey: e.condKey, applied: false }));
+    const content = await _renderConsolidatedContent(turn, flagEntries);
+
     await ChatMessage.create({
       speaker: { alias: game.i18n.localize("TB2E.GrindTracker.Title") },
       content,
-      type: CONST.CHAT_MESSAGE_STYLES.OTHER
-    });
-  }
-
-  /**
-   * Post a per-character card for a grind condition with an Apply button.
-   * @param {Actor} actor
-   * @param {string} condKey  e.g. "hungry", "exhausted", etc.
-   */
-  static async #postGrindConditionCard(actor, condKey) {
-    const condLabel = game.i18n.localize(
-      "TB2E.Condition." + condKey[0].toUpperCase() + condKey.slice(1)
-    );
-    const content = await foundry.applications.handlebars.renderTemplate(
-      "systems/tb2e/templates/chat/grind-condition.hbs",
-      {
-        actorImg: actor.img,
-        actorName: actor.name,
-        label: game.i18n.localize("TB2E.GrindTracker.ConditionLabel"),
-        body: game.i18n.format("TB2E.GrindTracker.ConditionBody", { name: actor.name }),
-        condLabel,
-        applyLabel: game.i18n.format("TB2E.GrindTracker.ApplyCondition", { condition: condLabel })
-      }
-    );
-    await ChatMessage.create({
-      speaker: ChatMessage.getSpeaker({ actor }),
-      content,
       type: CONST.CHAT_MESSAGE_STYLES.OTHER,
-      flags: { tb2e: { grindCondition: true, actorId: actor.id, condKey } }
+      flags: { tb2e: { grindCondition: true, turn, entries: flagEntries } }
     });
   }
 
@@ -471,13 +444,23 @@ export default class GrindTracker extends HandlebarsApplicationMixin(Application
 }
 
 /**
- * Register the "Apply condition" button on grind condition chat cards.
+ * Register the "Apply condition" button(s) on grind condition chat cards.
  * Called from the renderChatMessageHTML hook in tb2e.mjs.
+ * Handles both new consolidated cards (entries array) and legacy single-actor cards.
  * @param {ChatMessage} message
  * @param {HTMLElement} html
  */
 export function activateGrindConditionListeners(message, html) {
   if ( !message.getFlag("tb2e", "grindCondition") ) return;
+
+  // New consolidated format
+  const entries = message.getFlag("tb2e", "entries");
+  if ( entries ) {
+    _activateConsolidatedListeners(message, html);
+    return;
+  }
+
+  // Legacy single-actor format (backward compat for old messages)
   const btn = html.querySelector("[data-action='applyGrindCondition']");
   if ( !btn ) return;
   if ( message.getFlag("tb2e", "conditionApplied") ) {
@@ -496,4 +479,121 @@ export function activateGrindConditionListeners(message, html) {
     btn.disabled = true;
     btn.textContent = game.i18n.localize("TB2E.GrindTracker.ConditionApplied");
   });
+}
+
+/**
+ * Render the consolidated grind card content from flag data.
+ * Used both on initial create and when re-rendering after an apply.
+ * @param {number} turn
+ * @param {Array<{actorId: string, condKey: string, applied: boolean}>} entries
+ * @returns {Promise<string>}
+ */
+async function _renderConsolidatedContent(turn, entries) {
+  const templateEntries = entries.map(e => {
+    const actor = game.actors.get(e.actorId);
+    const condLabel = game.i18n.localize(
+      "TB2E.Condition." + e.condKey[0].toUpperCase() + e.condKey.slice(1)
+    );
+    return {
+      actorId: e.actorId,
+      actorImg: actor?.img ?? "icons/svg/mystery-man.svg",
+      actorName: actor?.name ?? "Unknown",
+      condKey: e.condKey,
+      condLabel,
+      applied: e.applied,
+      applyLabel: game.i18n.format("TB2E.GrindTracker.ApplyCondition", { condition: condLabel })
+    };
+  });
+
+  return foundry.applications.handlebars.renderTemplate(
+    "systems/tb2e/templates/chat/grind-consolidated.hbs",
+    {
+      body: game.i18n.format("TB2E.GrindTracker.GrindTicksBody", { turn }),
+      entries: templateEntries,
+      allApplied: entries.every(e => e.applied),
+      applyAllLabel: game.i18n.localize("TB2E.GrindTracker.ApplyAll")
+    }
+  );
+}
+
+/**
+ * Activate listeners for the consolidated grind condition card.
+ * GM updates the message directly; players use the mailbox pattern (pendingGrindApply flag).
+ * @param {ChatMessage} message
+ * @param {HTMLElement} html
+ */
+function _activateConsolidatedListeners(message, html) {
+  // Individual Apply buttons
+  for ( const btn of html.querySelectorAll("[data-action='applyGrindCondition']") ) {
+    btn.addEventListener("click", async (event) => {
+      event.preventDefault();
+      const { actorId, condKey } = btn.dataset;
+      const actor = game.actors.get(actorId);
+      if ( !actor?.isOwner ) return;
+
+      if ( game.user.isGM ) {
+        await actor.update({ [`system.conditions.${condKey}`]: true });
+        await _applyGrindEntry(message, actorId);
+      } else {
+        // Player: apply condition + signal GM via mailbox
+        await actor.update({
+          [`system.conditions.${condKey}`]: true,
+          "flags.tb2e.pendingGrindApply": message.id
+        });
+      }
+    });
+  }
+
+  // Apply All button
+  const applyAllBtn = html.querySelector("[data-action='applyAllGrindConditions']");
+  if ( applyAllBtn ) {
+    applyAllBtn.addEventListener("click", async (event) => {
+      event.preventDefault();
+      const currentEntries = message.getFlag("tb2e", "entries");
+
+      for ( const entry of currentEntries ) {
+        if ( entry.applied ) continue;
+        const actor = game.actors.get(entry.actorId);
+        if ( !actor?.isOwner ) continue;
+
+        if ( game.user.isGM ) {
+          await actor.update({ [`system.conditions.${entry.condKey}`]: true });
+          await _applyGrindEntry(message, entry.actorId);
+        } else {
+          await actor.update({
+            [`system.conditions.${entry.condKey}`]: true,
+            "flags.tb2e.pendingGrindApply": message.id
+          });
+        }
+      }
+    });
+  }
+}
+
+/**
+ * Mark a single actor's grind entry as applied, re-render the card, and update the message.
+ * Called by the GM — either directly (GM click) or from the mailbox hook.
+ * @param {ChatMessage} message
+ * @param {string} actorId
+ */
+async function _applyGrindEntry(message, actorId) {
+  const updatedEntries = foundry.utils.deepClone(message.getFlag("tb2e", "entries"));
+  const idx = updatedEntries.findIndex(e => e.actorId === actorId);
+  if ( idx < 0 || updatedEntries[idx].applied ) return;
+  updatedEntries[idx].applied = true;
+
+  const content = await _renderConsolidatedContent(message.getFlag("tb2e", "turn"), updatedEntries);
+  await message.update({ content, "flags.tb2e.entries": updatedEntries });
+}
+
+/**
+ * GM-side mailbox processor for grind condition apply.
+ * Called from the updateActor hook in tb2e.mjs when pendingGrindApply is detected.
+ * @param {Actor} actor
+ * @param {string} messageId
+ */
+export async function processGrindApplyMailbox(actor, messageId) {
+  const message = game.messages.get(messageId);
+  if ( message ) await _applyGrindEntry(message, actor.id);
+  await actor.unsetFlag("tb2e", "pendingGrindApply");
 }

--- a/system.json
+++ b/system.json
@@ -1,10 +1,10 @@
 {
   "id": "tb2e",
   "title": "Torchbearer 2nd Edition",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "url": "https://github.com/adamhjk/tb2e-foundry-vtt",
   "manifest": "https://github.com/adamhjk/tb2e-foundry-vtt/releases/latest/download/system.json",
-  "download": "https://github.com/adamhjk/tb2e-foundry-vtt/releases/download/release-0.2.5/tb2e-release-0.2.5.zip",
+  "download": "https://github.com/adamhjk/tb2e-foundry-vtt/releases/download/release-0.2.6/tb2e-release-0.2.6.zip",
   "compatibility": {
     "minimum": "13",
     "verified": "13"

--- a/tb2e.css
+++ b/tb2e.css
@@ -5208,6 +5208,48 @@ body.theme-dark .tb2e.sheet .torchbearer-logo,
   letter-spacing: 0.06em;
   color: var(--tb-amber-bright);
 }
+/* -------------------------------------------- */
+/*  Consolidated Grind Card                     */
+/* -------------------------------------------- */
+.grind-consolidated-card .grind-entries {
+  display: flex;
+  flex-direction: column;
+}
+.grind-consolidated-card .grind-entry {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--tb-border);
+}
+.grind-consolidated-card .grind-entry .card-portrait {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  object-fit: cover;
+  border: 1px solid var(--tb-red);
+  flex-shrink: 0;
+}
+.grind-consolidated-card .grind-entry .card-name {
+  flex: 1;
+  min-width: 0;
+  font-weight: bold;
+  font-size: 0.85rem;
+}
+.grind-consolidated-card .grind-apply-btn {
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  padding: 0.25rem 0.5rem;
+}
+.grind-consolidated-card .grind-entry--applied {
+  opacity: 0.7;
+}
+.grind-consolidated-card .grind-applied-label {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: var(--tb-green);
+}
 /* ============================================ */
 /*  Conflict Tracker                            */
 /* ============================================ */

--- a/tb2e.mjs
+++ b/tb2e.mjs
@@ -7,7 +7,7 @@ import { PendingVersusRegistry, resolveVersus, processVersusFinalize, handleTrai
 import { activatePostRollListeners, activateNatureCrisisListeners, activateWiseAdvancementListeners, processSynergyMailbox, processWiseAdvancementMailbox } from "./module/dice/post-roll.mjs";
 import { activateSpellSourceListeners } from "./module/dice/spell-casting.mjs";
 import { activateBurdenListeners } from "./module/dice/invocation-casting.mjs";
-import { activateGrindConditionListeners } from "./module/applications/grind-tracker.mjs";
+import { activateGrindConditionListeners, processGrindApplyMailbox } from "./module/applications/grind-tracker.mjs";
 import WizardCompendiumsConfig from "./module/applications/settings/wizard-compendiums-config.mjs";
 
 Hooks.once("init", function() {
@@ -125,7 +125,8 @@ Hooks.once("init", function() {
     "systems/tb2e/templates/chat/conflict-compromise.hbs",
     "systems/tb2e/templates/chat/torch-expired.hbs",
     "systems/tb2e/templates/chat/grind-tick.hbs",
-    "systems/tb2e/templates/chat/grind-condition.hbs"
+    "systems/tb2e/templates/chat/grind-condition.hbs",
+    "systems/tb2e/templates/chat/grind-consolidated.hbs"
   ]);
 
   console.log("Torchbearer 2E | System initialized.");
@@ -238,6 +239,9 @@ Hooks.on("updateActor", (actor, changes, options, userId) => {
       actor.unsetFlag("tb2e", "pendingLightExtinguish");
     });
   }
+
+  const pendingGrindApply = changes.flags?.tb2e?.pendingGrindApply;
+  if ( pendingGrindApply ) processGrindApplyMailbox(actor, pendingGrindApply);
 
 });
 

--- a/templates/chat/grind-consolidated.hbs
+++ b/templates/chat/grind-consolidated.hbs
@@ -1,0 +1,37 @@
+<div class="tb2e-chat-card card-accent--red grind-consolidated-card">
+  <div class="card-body grind-tick-body">
+    <p>{{body}}</p>
+  </div>
+
+  <div class="card-banner banner-dark">
+    <i class="fa-solid fa-hourglass-end"></i>
+    <span>{{localize "TB2E.GrindTracker.GrindTicks"}}</span>
+  </div>
+
+  <div class="grind-entries">
+    {{#each entries}}
+    <div class="grind-entry {{#if this.applied}}grind-entry--applied{{/if}}" data-actor-id="{{this.actorId}}">
+      <img class="card-portrait" src="{{this.actorImg}}" alt="{{this.actorName}}">
+      <span class="card-name">{{this.actorName}}</span>
+      {{#if this.applied}}
+      <span class="grind-applied-label"><i class="fa-solid fa-check"></i> {{this.condLabel}}</span>
+      {{else}}
+      <button type="button" class="card-btn card-btn--amber grind-apply-btn"
+        data-action="applyGrindCondition"
+        data-actor-id="{{this.actorId}}"
+        data-cond-key="{{this.condKey}}">
+        {{this.applyLabel}}
+      </button>
+      {{/if}}
+    </div>
+    {{/each}}
+  </div>
+
+  {{#unless allApplied}}
+  <div class="card-actions">
+    <button type="button" class="card-btn card-btn--amber" data-action="applyAllGrindConditions">
+      {{applyAllLabel}}
+    </button>
+  </div>
+  {{/unless}}
+</div>


### PR DESCRIPTION
## Summary

Resolves #7 — the grind tracker was posting N+1 chat messages (1 announcement + 1 per character) every grind turn, creating significant clutter.

- **Single consolidated card** replaces all per-character messages: shows the grind tick announcement, then lists each affected character with portrait, name, and individual "Apply {condition}" button
- **Apply All** button at the bottom for the GM to batch-apply all conditions at once
- **Live card updates** — clicking Apply re-renders the card HTML so all connected clients see the applied state (checkmark + condition name replaces the button, row dims, Apply All disappears when all applied)
- **Mailbox pattern** for player clicks — since the chat message is GM-owned, players write `pendingGrindApply` flag on their actor; GM hook processes it and updates the card
- **Backward compatible** — old per-character grind condition messages in the chat log still render and function correctly
- **Version bump** to 0.2.6 for release

## Test plan

- [ ] With 2+ characters in a scene, advance the grind to a grind turn — verify a single consolidated card appears (not N+1 messages)
- [ ] Each character row shows portrait, name, and "Apply {condition}" button
- [ ] Click individual Apply as GM — button replaced with checkmark + condition name, row dims, condition applied to character sheet
- [ ] Click Apply All as GM — all remaining conditions applied, Apply All button disappears
- [ ] As a player, click Apply on your own character — condition applied via mailbox, card updates for all clients
- [ ] Reload page — applied state persists (card re-renders correctly from flags)
- [ ] Old grind-condition messages in chat log still render with working Apply button

🤖 Generated with [Claude Code](https://claude.com/claude-code)